### PR TITLE
remove unnecessary properties fields

### DIFF
--- a/pkg/models/properties/page.go
+++ b/pkg/models/properties/page.go
@@ -9,24 +9,15 @@ import (
 
 func TransactionDateProperty(date time.Time) notion.DatabasePageProperty {
 	notionDate := notion.NewDateTime(date, false)
-	tz := "America/Sao_Paulo"
 	return notion.DatabasePageProperty{
-		ID:   "transaction_date",
-		Name: "Transaction Date",
-		Type: notion.DBPropTypeDate,
 		Date: &notion.Date{
-			Start:    notionDate,
-			End:      &notionDate,
-			TimeZone: &tz,
+			Start: notionDate,
 		},
 	}
 }
 
 func OperationProperty(operationType ofx.OFXOperationType) notion.DatabasePageProperty {
 	return notion.DatabasePageProperty{
-		ID:   "operation",
-		Name: "Operation",
-		Type: notion.DBPropTypeSelect,
 		Select: &notion.SelectOptions{
 			Name: string(operationType),
 		},
@@ -35,9 +26,6 @@ func OperationProperty(operationType ofx.OFXOperationType) notion.DatabasePagePr
 
 func DestinationProperty(destination string) notion.DatabasePageProperty {
 	return notion.DatabasePageProperty{
-		ID:   "destination",
-		Name: "Destination",
-		Type: notion.DBPropTypeRichText,
 		RichText: []notion.RichText{
 			{
 				Type: "text",
@@ -49,18 +37,12 @@ func DestinationProperty(destination string) notion.DatabasePageProperty {
 
 func AmountProperty(amount float64) notion.DatabasePageProperty {
 	return notion.DatabasePageProperty{
-		ID:   "amount",
-		Name: "Amount",
-		Type: notion.DBPropTypeNumber,
 		Number: &amount,
 	}
 }
 
 func MemoProperty(memo string) notion.DatabasePageProperty {
 	return notion.DatabasePageProperty{
-		ID:   "memo",
-		Name: "Memo",
-		Type: notion.DBPropTypeRichText,
 		RichText: []notion.RichText{
 			{
 				Type: "text",
@@ -72,9 +54,6 @@ func MemoProperty(memo string) notion.DatabasePageProperty {
 
 func TransactionIDProperty(transactionID string) notion.DatabasePageProperty {
 	return notion.DatabasePageProperty{
-		ID:   "transaction_id",
-		Name: "Transaction ID",
-		Type: notion.DBPropTypeRichText,
 		RichText: []notion.RichText{
 			{
 				Type: "text",


### PR DESCRIPTION
This pull request simplifies the construction of Notion database page properties by removing the explicit setting of property IDs, names, and types in the property helper functions. The focus is now solely on setting the property values, which streamlines the code and reduces redundancy.

**Refactoring of property helper functions:**

* Removed the explicit `ID`, `Name`, and `Type` fields from the return values of the following property functions: `TransactionDateProperty`, `OperationProperty`, `DestinationProperty`, `AmountProperty`, `MemoProperty`, and `TransactionIDProperty`. Now, these functions only set the relevant value fields (e.g., `Date`, `Select`, `RichText`, `Number`). [[1]](diffhunk://#diff-7f26121bc2dc1ab885c803599d202951ccd1d1f275b0d6333f4de994e2928ef7L12-L29) [[2]](diffhunk://#diff-7f26121bc2dc1ab885c803599d202951ccd1d1f275b0d6333f4de994e2928ef7L38-L40) [[3]](diffhunk://#diff-7f26121bc2dc1ab885c803599d202951ccd1d1f275b0d6333f4de994e2928ef7L52-L63) [[4]](diffhunk://#diff-7f26121bc2dc1ab885c803599d202951ccd1d1f275b0d6333f4de994e2928ef7L75-L77)

* In `TransactionDateProperty`, also removed the explicit timezone setting, further simplifying the date property construction.