### PR TITLE
Migrate title property constructor to the BuildPageProperties function

### DIFF
--- a/pkg/models/properties/page.go
+++ b/pkg/models/properties/page.go
@@ -62,3 +62,14 @@ func TransactionIDProperty(transactionID string) notion.DatabasePageProperty {
 		},
 	}
 }
+
+func TitleProperty(title string) notion.DatabasePageProperty {
+	return notion.DatabasePageProperty{
+		Title: []notion.RichText{
+			{
+				Type: "text",
+				Text: &notion.Text{Content: title},
+			},
+		},
+	}
+}

--- a/pkg/notion/page/page.go
+++ b/pkg/notion/page/page.go
@@ -17,7 +17,6 @@ type PageClient interface {
 }
 
 type PageData struct {
-	Title      string
 	DatabaseId string
 	Properties *notion.DatabasePageProperties
 }
@@ -37,7 +36,6 @@ func (p *Page) SearchPages(pageId string) (*notion.Page, error) {
 
 func (p *Page) BuildPage(databaseID string, statement statement.Statement) PageData {
 	return PageData{
-		Title:      strings.Join([]string{string(statement.Operation), statement.Destination}, "-"),
 		DatabaseId: databaseID,
 		Properties: BuildPageProperties(statement),
 	}
@@ -48,7 +46,6 @@ func (p *Page) CreatePageParams(pageData PageData) notion.CreatePageParams {
 		ParentType:             notion.ParentTypeDatabase,
 		ParentID:               pageData.DatabaseId,
 		DatabasePageProperties: pageData.Properties,
-		Title:                  []notion.RichText{{PlainText: pageData.Title}},
 	}
 }
 
@@ -64,7 +61,9 @@ func (p *Page) CreatePage(pageData PageData) error {
 }
 
 func BuildPageProperties(statement statement.Statement) *notion.DatabasePageProperties {
+	title := strings.Join([]string{string(statement.Operation), statement.Destination}, "-")
 	return &notion.DatabasePageProperties{
+		"Name":             properties.TitleProperty(title), // Title property - the page name in the database
 		"Transaction Date": properties.TransactionDateProperty(statement.TransactionDate),
 		"Operation":        properties.OperationProperty(statement.Operation),
 		"Destination":      properties.DestinationProperty(statement.Destination),


### PR DESCRIPTION
This pull request refactors how the title property is handled when creating Notion database pages. The title is now included directly in the page properties rather than as a separate field, which streamlines the creation process and aligns with Notion's API requirements.

**Refactoring of title property handling:**

* Removed the `Title` field from the `PageData` struct and eliminated its usage throughout the `pkg/notion/page/page.go` file. The title is no longer passed separately but is instead managed as part of the properties. [[1]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L20) [[2]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L40) [[3]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L51)
* Added a new `TitleProperty` helper function in `pkg/models/properties/page.go` to construct the Notion title property in the correct format.
* Updated the `BuildPageProperties` function to generate and include the title property (named `"Name"`) as part of the database page properties, using the new helper.