### PR TITLE
Adjust upload-statement cobra cmd in entrypoint

### DIFF
--- a/cmd/nankion/main.go
+++ b/cmd/nankion/main.go
@@ -79,14 +79,14 @@ func main() {
 		},
 	}
 
-	updateDatabaseProperty := &cobra.Command{
-		Use:   "update-property",
-		Short: "Get a Notion database properties by ID",
-		Args:  cobra.ExactArgs(1),
+	uploadStatement := &cobra.Command{
+		Use:   "upload-statement [database-id] [statement-filepath]",
+		Short: "Upload finantial statement to Notion",
+		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			databaseID := args[0]
 			filePath := args[1]
-			fmt.Println("Updating database property")
+			fmt.Println("Uploading statement...")
 			nl := nankionNotion.NewNotionLoader()
 			err := nl.UploadReport(databaseID, filePath)
 			if err != nil {
@@ -97,7 +97,7 @@ func main() {
 
 	databaseCmd.AddCommand(getDatabaseCmd)
 	databaseCmd.AddCommand(listDatabasePropertiesCmd)
-	databaseCmd.AddCommand(updateDatabaseProperty)
+	databaseCmd.AddCommand(uploadStatement)
 
 	reportCmd.AddCommand(printReportCmd)
 


### PR DESCRIPTION
This pull request updates the CLI by replacing the previous command for updating a Notion database property with a new command for uploading a financial statement to Notion. The new command changes the expected arguments and the underlying logic to better align with the application's use case.

**Command changes:**

* Replaced the `update-property` command with a new `upload-statement` command in `cmd/nankion/main.go`. The new command takes a `database-id` and a `statement-filepath` as arguments and uploads a financial statement to Notion using the `UploadReport` method. [[1]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L82-R89) [[2]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L100-R100)