### PR TITLE
Implement Page interface and refactor Page struct; add MockPageClient for testing

### DIFF
--- a/pkg/notion/page/mocks/page.go
+++ b/pkg/notion/page/mocks/page.go
@@ -1,0 +1,28 @@
+package mocks
+
+import (
+	"errors"
+
+	"github.com/rodrigoTcarmo/nankion/pkg/notion/page"
+	"github.com/rodrigoTcarmo/nankion/pkg/statement"
+)
+
+// MockPageClient implements page.Page for testing
+type MockPageClient struct {
+	BuildPageFunc  func(databaseID string, statement statement.Statement) page.PageData
+	CreatePageFunc func(pageData page.PageData) error
+}
+
+func (m *MockPageClient) BuildPage(databaseID string, stmt statement.Statement) page.PageData {
+	if m.BuildPageFunc != nil {
+		return m.BuildPageFunc(databaseID, stmt)
+	}
+	return page.PageData{}
+}
+
+func (m *MockPageClient) CreatePage(pageData page.PageData) error {
+	if m.CreatePageFunc != nil {
+		return m.CreatePageFunc(pageData)
+	}
+	return errors.New("CreatePageFunc not set")
+}

--- a/pkg/notion/page/page.go
+++ b/pkg/notion/page/page.go
@@ -16,16 +16,21 @@ type PageClient interface {
 	CreatePage(string, string, *notion.DatabasePageProperties) error
 }
 
+type Page interface {
+	BuildPage(databaseID string, statement statement.Statement) PageData
+	CreatePage(pageData PageData) error
+}
+
 type PageData struct {
 	DatabaseId string
 	Properties *notion.DatabasePageProperties
 }
 
-type Page struct {
+type page struct {
 	client *notion.Client
 }
 
-func (p *Page) SearchPages(pageId string) (*notion.Page, error) {
+func (p *page) SearchPages(pageId string) (*notion.Page, error) {
 	pageFound, err := p.client.FindPageByID(context.Background(), pageId)
 	if err != nil {
 		return nil, fmt.Errorf("error trying to find page by ID: %v", err)
@@ -34,14 +39,14 @@ func (p *Page) SearchPages(pageId string) (*notion.Page, error) {
 	return &pageFound, nil
 }
 
-func (p *Page) BuildPage(databaseID string, statement statement.Statement) PageData {
+func (p *page) BuildPage(databaseID string, statement statement.Statement) PageData {
 	return PageData{
 		DatabaseId: databaseID,
 		Properties: BuildPageProperties(statement),
 	}
 }
 
-func (p *Page) CreatePageParams(pageData PageData) notion.CreatePageParams {
+func (p *page) CreatePageParams(pageData PageData) notion.CreatePageParams {
 	return notion.CreatePageParams{
 		ParentType:             notion.ParentTypeDatabase,
 		ParentID:               pageData.DatabaseId,
@@ -49,7 +54,7 @@ func (p *Page) CreatePageParams(pageData PageData) notion.CreatePageParams {
 	}
 }
 
-func (p *Page) CreatePage(pageData PageData) error {
+func (p *page) CreatePage(pageData PageData) error {
 	pageParams := p.CreatePageParams(pageData)
 
 	_, err := p.client.CreatePage(context.Background(), pageParams)
@@ -63,7 +68,7 @@ func (p *Page) CreatePage(pageData PageData) error {
 func BuildPageProperties(statement statement.Statement) *notion.DatabasePageProperties {
 	title := strings.Join([]string{string(statement.Operation), statement.Destination}, "-")
 	return &notion.DatabasePageProperties{
-		"Name":             properties.TitleProperty(title), // Title property - the page name in the database
+		"Name":             properties.TitleProperty(title),
 		"Transaction Date": properties.TransactionDateProperty(statement.TransactionDate),
 		"Operation":        properties.OperationProperty(statement.Operation),
 		"Destination":      properties.DestinationProperty(statement.Destination),
@@ -73,8 +78,8 @@ func BuildPageProperties(statement statement.Statement) *notion.DatabasePageProp
 	}
 }
 
-func NewPage() Page {
-	return Page{
+func NewPage() *page {
+	return &page{
 		client: notionclient.NewClient(),
 	}
 }


### PR DESCRIPTION
This pull request introduces a new `Page` interface to abstract page operations and adds a mock implementation for testing. It also updates the concrete page implementation to follow Go conventions and improves testability. The most important changes are:

**Abstraction and Interface Design:**

* Introduced a new `Page` interface in `page.go` to define `BuildPage` and `CreatePage` methods, decoupling the implementation from the interface and improving testability.

**Testing and Mocking:**

* Added `MockPageClient` in `mocks/page.go`, which implements the new `Page` interface, allowing for easier mocking and testing of page-related logic.

**Implementation Updates:**

* Updated the concrete implementation: renamed the struct from `Page` to `page` (unexported), updated method receivers accordingly, and changed `NewPage` to return a pointer to `page` instead of a value. This aligns with Go idioms and supports interface usage. [[1]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52R19-R33) [[2]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L37-R57) [[3]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L76-R82)

**Minor Cleanups:**

* Minor cleanup in the `BuildPageProperties` function for clarity (removed redundant comment).