### PR TITLE
Add page duplicity validation

### DIFF
--- a/cmd/nankion/main.go
+++ b/cmd/nankion/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	nankionNotion "github.com/rodrigoTcarmo/nankion/pkg/notion"
-	notionpage "github.com/rodrigoTcarmo/nankion/pkg/notion/page"
 	notiondatabase "github.com/rodrigoTcarmo/nankion/pkg/notion/database"
 	"github.com/rodrigoTcarmo/nankion/pkg/statement"
 	"github.com/spf13/cobra"
@@ -95,25 +94,10 @@ func main() {
 			}
 		},
 	}
-	searchStatement := &cobra.Command{
-		Use:   "search-statement [transaction-id]",
-		Short: "Search statement by transaction ID",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			transactionID := args[0]
-			np := notionpage.NewPage()
-			searchResponse, err := np.ValidatePageDuplicity(transactionID)
-			if err != nil {
-				fmt.Println("Error trying to search page by transaction ID: ", err)
-			}
-			fmt.Println("Search response\n", searchResponse)
-		},
-	}
 
 	databaseCmd.AddCommand(getDatabaseCmd)
 	databaseCmd.AddCommand(listDatabasePropertiesCmd)
 	databaseCmd.AddCommand(uploadStatement)
-	databaseCmd.AddCommand(searchStatement)
 	reportCmd.AddCommand(printReportCmd)
 
 	rootCmd.AddCommand(databaseCmd)

--- a/cmd/nankion/main.go
+++ b/cmd/nankion/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	nankionNotion "github.com/rodrigoTcarmo/nankion/pkg/notion"
+	notionpage "github.com/rodrigoTcarmo/nankion/pkg/notion/page"
 	notiondatabase "github.com/rodrigoTcarmo/nankion/pkg/notion/database"
 	"github.com/rodrigoTcarmo/nankion/pkg/statement"
 	"github.com/spf13/cobra"
@@ -94,11 +95,25 @@ func main() {
 			}
 		},
 	}
+	searchStatement := &cobra.Command{
+		Use:   "search-statement [transaction-id]",
+		Short: "Search statement by transaction ID",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			transactionID := args[0]
+			np := notionpage.NewPage()
+			searchResponse, err := np.ValidatePageDuplicity(transactionID)
+			if err != nil {
+				fmt.Println("Error trying to search page by transaction ID: ", err)
+			}
+			fmt.Println("Search response\n", searchResponse)
+		},
+	}
 
 	databaseCmd.AddCommand(getDatabaseCmd)
 	databaseCmd.AddCommand(listDatabasePropertiesCmd)
 	databaseCmd.AddCommand(uploadStatement)
-
+	databaseCmd.AddCommand(searchStatement)
 	reportCmd.AddCommand(printReportCmd)
 
 	rootCmd.AddCommand(databaseCmd)

--- a/pkg/notion/notion.go
+++ b/pkg/notion/notion.go
@@ -51,8 +51,12 @@ func (n *Notion) UploadReport(databaseID, filePath string) error {
 func (n *Notion) uploadPages(databaseID string, report *statement.Report) error {
 	var errs []error
 	for _, statement := range report.Statements {
-		newPage := n.page.BuildPage(databaseID, statement)
-		if err := n.page.CreatePage(newPage); err != nil {
+		newPage, err := n.page.BuildPage(databaseID, statement)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error trying to build page for %s: %w", statement.Destination, err))
+			continue
+		}
+		if err := n.page.CreatePage(*newPage); err != nil {
 			errs = append(errs, fmt.Errorf("error trying to create page for %s: %w", statement.Destination, err))
 		}
 	}

--- a/pkg/notion/notion_test.go
+++ b/pkg/notion/notion_test.go
@@ -200,8 +200,8 @@ func TestUploadReport(t *testing.T) {
 			// Setup page mock with call tracking
 			var mockPage *pagemock.MockPageClient
 			mockPage = &pagemock.MockPageClient{
-				BuildPageFunc: func(dbID string, stmt statement.Statement) page.PageData {
-					return page.PageData{DatabaseId: dbID}
+				BuildPageFunc: func(dbID string, stmt statement.Statement) (*page.PageData, error) {
+					return &page.PageData{DatabaseId: dbID}, nil
 				},
 				CreatePageFunc: func(pageData page.PageData) error {
 					createPageCalls++

--- a/pkg/notion/page/mocks/page.go
+++ b/pkg/notion/page/mocks/page.go
@@ -9,15 +9,15 @@ import (
 
 // MockPageClient implements page.Page for testing
 type MockPageClient struct {
-	BuildPageFunc  func(databaseID string, statement statement.Statement) page.PageData
+	BuildPageFunc  func(databaseID string, statement statement.Statement) (*page.PageData, error)
 	CreatePageFunc func(pageData page.PageData) error
 }
 
-func (m *MockPageClient) BuildPage(databaseID string, stmt statement.Statement) page.PageData {
+func (m *MockPageClient) BuildPage(databaseID string, stmt statement.Statement) (*page.PageData, error) {
 	if m.BuildPageFunc != nil {
 		return m.BuildPageFunc(databaseID, stmt)
 	}
-	return page.PageData{}
+	return nil, errors.New("BuildPageFunc not set")
 }
 
 func (m *MockPageClient) CreatePage(pageData page.PageData) error {

--- a/pkg/notion/page/page.go
+++ b/pkg/notion/page/page.go
@@ -11,14 +11,11 @@ import (
 	"github.com/rodrigoTcarmo/nankion/pkg/statement"
 )
 
-type PageClient interface {
-	SearchPages(string) (*notion.Page, error)
-	CreatePage(string, string, *notion.DatabasePageProperties) error
-}
-
 type Page interface {
-	BuildPage(databaseID string, statement statement.Statement) PageData
-	CreatePage(pageData PageData) error
+	SearchPages(string) (*notion.Page, error)
+	BuildPage(string, statement.Statement) (*PageData, error)
+	CreatePage(PageData) error
+	ValidatePageDuplicity(string) (*notion.SearchResponse, error)
 }
 
 type PageData struct {
@@ -39,11 +36,32 @@ func (p *page) SearchPages(pageId string) (*notion.Page, error) {
 	return &pageFound, nil
 }
 
-func (p *page) BuildPage(databaseID string, statement statement.Statement) PageData {
-	return PageData{
-		DatabaseId: databaseID,
-		Properties: BuildPageProperties(statement),
+func (p *page) BuildPage(databaseID string, statement statement.Statement) (*PageData, error) {
+	properties, err := p.BuildPageProperties(statement)
+	if err != nil {
+		return nil, err
 	}
+
+	pageData := &PageData{
+		DatabaseId: databaseID,
+		Properties: properties,
+	}
+	return pageData, nil
+}
+
+func (p *page) ValidatePageDuplicity(query string) (*notion.SearchResponse, error) {
+	searchResponse, err := p.client.Search(context.Background(), &notion.SearchOpts{
+		Query: query,
+		Filter: &notion.SearchFilter{
+			Property: "object",
+			Value:    "page",
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error trying to search page by transaction ID: %v", err)
+	}
+
+	return &searchResponse, nil
 }
 
 func (p *page) CreatePageParams(pageData PageData) notion.CreatePageParams {
@@ -65,8 +83,18 @@ func (p *page) CreatePage(pageData PageData) error {
 	return nil
 }
 
-func BuildPageProperties(statement statement.Statement) *notion.DatabasePageProperties {
-	title := strings.Join([]string{string(statement.Operation), statement.Destination}, "-")
+func (p *page) BuildPageProperties(statement statement.Statement) (*notion.DatabasePageProperties, error) {
+	
+	searchResponse, err := p.ValidatePageDuplicity(statement.TransactionID)
+	if err != nil {
+		return nil, fmt.Errorf("error trying to validate page duplicity: %v", err)
+	}
+	
+	if len(searchResponse.Results) > 0 {
+		return nil, fmt.Errorf("page already exists")
+	}
+	
+	title := strings.Join([]string{string(statement.Operation), statement.Destination, statement.TransactionID}, "-")
 	return &notion.DatabasePageProperties{
 		"Name":             properties.TitleProperty(title),
 		"Transaction Date": properties.TransactionDateProperty(statement.TransactionDate),
@@ -75,10 +103,10 @@ func BuildPageProperties(statement statement.Statement) *notion.DatabasePageProp
 		"Amount":           properties.AmountProperty(statement.Amount),
 		"Memo":             properties.MemoProperty(statement.Memo),
 		"Transaction ID":   properties.TransactionIDProperty(statement.TransactionID),
-	}
+	}, nil
 }
 
-func NewPage() *page {
+func NewPage() Page {
 	return &page{
 		client: notionclient.NewClient(),
 	}

--- a/pkg/notion/page/page.go
+++ b/pkg/notion/page/page.go
@@ -12,10 +12,8 @@ import (
 )
 
 type Page interface {
-	SearchPages(string) (*notion.Page, error)
 	BuildPage(string, statement.Statement) (*PageData, error)
 	CreatePage(PageData) error
-	ValidatePageDuplicity(string) (*notion.SearchResponse, error)
 }
 
 type PageData struct {
@@ -25,15 +23,6 @@ type PageData struct {
 
 type page struct {
 	client *notion.Client
-}
-
-func (p *page) SearchPages(pageId string) (*notion.Page, error) {
-	pageFound, err := p.client.FindPageByID(context.Background(), pageId)
-	if err != nil {
-		return nil, fmt.Errorf("error trying to find page by ID: %v", err)
-	}
-
-	return &pageFound, nil
 }
 
 func (p *page) BuildPage(databaseID string, statement statement.Statement) (*PageData, error) {
@@ -49,7 +38,7 @@ func (p *page) BuildPage(databaseID string, statement statement.Statement) (*Pag
 	return pageData, nil
 }
 
-func (p *page) ValidatePageDuplicity(query string) (*notion.SearchResponse, error) {
+func (p *page) validatePageDuplicity(query string) (*notion.SearchResponse, error) {
 	searchResponse, err := p.client.Search(context.Background(), &notion.SearchOpts{
 		Query: query,
 		Filter: &notion.SearchFilter{
@@ -85,7 +74,7 @@ func (p *page) CreatePage(pageData PageData) error {
 
 func (p *page) BuildPageProperties(statement statement.Statement) (*notion.DatabasePageProperties, error) {
 	
-	searchResponse, err := p.ValidatePageDuplicity(statement.TransactionID)
+	searchResponse, err := p.validatePageDuplicity(statement.TransactionID)
 	if err != nil {
 		return nil, fmt.Errorf("error trying to validate page duplicity: %v", err)
 	}


### PR DESCRIPTION
This pull request refactors the Notion page creation logic to improve error handling and prevent duplicate pages based on transaction IDs. The most significant changes involve updating the `BuildPage` and `BuildPageProperties` methods to return errors, validating for page duplicity, and updating interfaces and mocks accordingly.

**Refactoring for error handling and duplicate prevention:**

* The `BuildPage` and `BuildPageProperties` methods in `page.go` now return errors, allowing upstream logic to handle failures gracefully. This includes a check to prevent creating duplicate pages based on the transaction ID. [[1]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L33-R53) [[2]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L68-R86)
* The `uploadPages` method in `notion.go` is updated to handle errors from `BuildPage`, appending them to the error list and continuing with the next statement if a failure occurs.

**Interface and mock updates:**

* The `Page` interface and its mock implementation are updated to reflect the new error-returning signatures for `BuildPage`. The related test code is also updated to use the new function signatures. [[1]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L14-R16) [[2]](diffhunk://#diff-2c86588cd912d510d8e4a941925351c72202543b011f366f1aa1cddbfd2ab7f6L12-R20) [[3]](diffhunk://#diff-9235542781305622c733ab1610e3bbce79581bf642b62016cfcbf6c51cd4362dL203-R204)

**Minor cleanup:**

* Unused or redundant code is removed, such as the old `SearchPages` and non-error-returning `BuildPage` implementations.
* Minor command registration cleanup in `main.go`.