### PR TITLE
Add credit card OFX statement reader feature

### DIFF
--- a/pkg/statement/reader.go
+++ b/pkg/statement/reader.go
@@ -31,6 +31,7 @@ func CreateReport(response *ofxgo.Response) (*Report, error) {
 		finalBalance float64
 	)
 
+	// Process bank statements
 	for _, msg := range response.Bank {
 		statementResponse, ok := msg.(*ofxgo.StatementResponse)
 		if !ok {
@@ -45,6 +46,25 @@ func CreateReport(response *ofxgo.Response) (*Report, error) {
 			return nil, fmt.Errorf("unable to parse transactions: %w", err)
 		}
 	}
+
+	// Process credit card statements
+	for _, msg := range response.CreditCard {
+		ccStatementResponse, ok := msg.(*ofxgo.CCStatementResponse)
+		if !ok {
+			continue
+		}
+		// Get final balance from LEDGERBAL
+		finalBalance, _ = ccStatementResponse.BalAmt.Float64()
+
+		if ccStatementResponse.BankTranList != nil {
+			var err error
+			statements, err = parseTransactions(ccStatementResponse.BankTranList.Transactions)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse credit card transactions: %w", err)
+			}
+		}
+	}
+
 	return &Report{
 		Statements:   statements,
 		FinalBalance: finalBalance,


### PR DESCRIPTION
This pull request updates the `CreateReport` function in `pkg/statement/reader.go` to add support for processing credit card statements in addition to bank statements. This ensures that both types of financial data are handled consistently when generating reports.

Enhancements to statement processing:

* Added logic to process credit card statements from the `response.CreditCard` field, including extracting the final balance and parsing credit card transactions.
* Added a clarifying comment to indicate the start of bank statement processing for improved code readability.