### PR TITLE
Add help printers to better track the process running

### DIFF
--- a/pkg/notion/notion.go
+++ b/pkg/notion/notion.go
@@ -58,6 +58,8 @@ func (n *Notion) uploadPages(databaseID string, report *statement.Report) error 
 		}
 		if err := n.page.CreatePage(*newPage); err != nil {
 			errs = append(errs, fmt.Errorf("error trying to create page for %s: %w", statement.Destination, err))
+		} else {
+			fmt.Println("Page succesfully created: ", statement.Memo)
 		}
 	}
 

--- a/pkg/notion/page/page.go
+++ b/pkg/notion/page/page.go
@@ -73,14 +73,13 @@ func (p *page) CreatePage(pageData PageData) error {
 }
 
 func (p *page) BuildPageProperties(statement statement.Statement) (*notion.DatabasePageProperties, error) {
-	
 	searchResponse, err := p.validatePageDuplicity(statement.TransactionID)
 	if err != nil {
 		return nil, fmt.Errorf("error trying to validate page duplicity: %v", err)
 	}
-	
+
 	if len(searchResponse.Results) > 0 {
-		return nil, fmt.Errorf("page already exists")
+		fmt.Printf("Warning! Transaction %s may already exist!\n", statement.TransactionID)
 	}
 	
 	title := strings.Join([]string{string(statement.Operation), statement.Destination, statement.TransactionID}, "-")


### PR DESCRIPTION
This pull request introduces improvements to the Notion integration by adding better feedback and warnings during page creation. The main changes focus on providing clearer console output for both successful and potentially duplicate page creation events.

Console output enhancements:

* Added a success message to indicate when a Notion page is successfully created, displaying the `statement.Memo` for context.
* Changed the duplicate page detection in `BuildPageProperties` to print a warning with the transaction ID, instead of returning an error immediately when a possible duplicate is found.