### PR TITLE
Remove page duplicity functionality due to unexpected behavior

### DIFF
--- a/pkg/notion/page/page.go
+++ b/pkg/notion/page/page.go
@@ -2,7 +2,6 @@ package page
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/dstotijn/go-notion"
@@ -38,21 +37,6 @@ func (p *page) BuildPage(databaseID string, statement statement.Statement) (*Pag
 	return pageData, nil
 }
 
-func (p *page) validatePageDuplicity(query string) (*notion.SearchResponse, error) {
-	searchResponse, err := p.client.Search(context.Background(), &notion.SearchOpts{
-		Query: query,
-		Filter: &notion.SearchFilter{
-			Property: "object",
-			Value:    "page",
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error trying to search page by transaction ID: %v", err)
-	}
-
-	return &searchResponse, nil
-}
-
 func (p *page) CreatePageParams(pageData PageData) notion.CreatePageParams {
 	return notion.CreatePageParams{
 		ParentType:             notion.ParentTypeDatabase,
@@ -73,15 +57,6 @@ func (p *page) CreatePage(pageData PageData) error {
 }
 
 func (p *page) BuildPageProperties(statement statement.Statement) (*notion.DatabasePageProperties, error) {
-	searchResponse, err := p.validatePageDuplicity(statement.TransactionID)
-	if err != nil {
-		return nil, fmt.Errorf("error trying to validate page duplicity: %v", err)
-	}
-
-	if len(searchResponse.Results) > 0 {
-		fmt.Printf("Warning! Transaction %s may already exist!\n", statement.TransactionID)
-	}
-	
 	title := strings.Join([]string{string(statement.Operation), statement.Destination, statement.TransactionID}, "-")
 	return &notion.DatabasePageProperties{
 		"Name":             properties.TitleProperty(title),


### PR DESCRIPTION
This pull request simplifies the `pkg/notion/page/page.go` file by removing the duplicate page validation logic. The main change is the elimination of the `validatePageDuplicity` function and its usage, which previously checked for existing pages with the same transaction ID before creating new ones.

Code cleanup and simplification:

* Removed the `validatePageDuplicity` function and its associated error handling and warning output from the `BuildPageProperties` method, streamlining the page creation process. [[1]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L41-L55) [[2]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L76-L84)
* Removed the unused `fmt` import, as it is no longer needed after eliminating the duplicity check and warning message.