### PR TITLE
Create logger feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 extrato.csv
 .vscode/
+*.log

--- a/cmd/nankion/main.go
+++ b/cmd/nankion/main.go
@@ -1,20 +1,23 @@
 package main
 
 import (
-	"fmt"
+	"log/slog"
 	"os"
 
+	"github.com/rodrigoTcarmo/nankion/pkg/log"
 	nankionNotion "github.com/rodrigoTcarmo/nankion/pkg/notion"
 	notiondatabase "github.com/rodrigoTcarmo/nankion/pkg/notion/database"
 	"github.com/spf13/cobra"
 )
 
 func main() {
+	log.Init()
+	defer log.Close()
 	rootCmd := &cobra.Command{
 		Use:   "nankion",
 		Short: "Nankion is a tool for managing your Notion databases",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Hello, Nankion!")
+			slog.Info("Hello, Nankion!")
 		},
 	}
 
@@ -34,14 +37,14 @@ func main() {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			databaseID := args[0]
-			fmt.Printf("Fetching database: %s\n", databaseID)
+			slog.Info("Fetching database", "databaseID", databaseID)
 			databaseCLI := notiondatabase.NewDatabase()
 			database, err := databaseCLI.GetDatabase(databaseID)
 			if err != nil {
-				fmt.Printf("Error fetching database: %s\n", err)
+				slog.Error("Error fetching database", "error", err.Error())
 				return
 			}
-			fmt.Println("Database\n", database)
+			slog.Info("Database info", "database", database)
 		},
 	}
 
@@ -51,14 +54,14 @@ func main() {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			databaseID := args[0]
-			fmt.Printf("Fetching database properties: %s\n", databaseID)
+			slog.Info("Fetching database properties", "databaseID", databaseID)
 			databaseCLI := notiondatabase.NewDatabase()
 			database, err := databaseCLI.ListDatabaseProperties(databaseID)
 			if err != nil {
-				fmt.Printf("Error fetching database properties: %s\n", err)
+				slog.Error("error fetching database properties", "error", err.Error())
 				return
 			}
-			fmt.Println("Database properties\n", database)
+			slog.Info("Database properties", "properties", database)
 		},
 	}
 
@@ -69,11 +72,11 @@ func main() {
 		Run: func(cmd *cobra.Command, args []string) {
 			databaseID := args[0]
 			filePath := args[1]
-			fmt.Println("Uploading statement...")
+			slog.Info("Uploading statement...")
 			nl := nankionNotion.NewNotionLoader()
 			err := nl.UploadReport(databaseID, filePath)
 			if err != nil {
-				fmt.Println("Error trying to update database: ", err)
+				slog.Info("Error trying to update database: ", err)
 			}
 		},
 	}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+)
+
+var logFile *os.File
+
+func Init() {
+	var err error
+	filename := fmt.Sprintf("nankion-%s.log", time.Now().Format("02-01-2006"))
+	logFile, err = os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		panic(err)
+	}
+
+	multiWriter := io.MultiWriter(os.Stdout, logFile)
+
+	logger := slog.New(slog.NewTextHandler(multiWriter, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+}
+
+// Close closes the log file. Call at application shutdown (optional).
+func Close() {
+	if logFile != nil {
+		logFile.Close()
+	}
+}

--- a/pkg/notion/notion.go
+++ b/pkg/notion/notion.go
@@ -3,6 +3,7 @@ package notion
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/dstotijn/go-notion"
 	"github.com/rodrigoTcarmo/nankion/pkg/models/properties"
@@ -59,7 +60,7 @@ func (n *Notion) uploadPages(databaseID string, report *statement.Report) error 
 		if err := n.page.CreatePage(*newPage); err != nil {
 			errs = append(errs, fmt.Errorf("error trying to create page for %s: %w", statement.Destination, err))
 		} else {
-			fmt.Println("Page succesfully created: ", statement.Memo)
+			slog.Info("Page successfully created", "memo", statement.Memo, "destination", statement.Destination)
 		}
 	}
 


### PR DESCRIPTION
This pull request refactors the logging throughout the application to use the structured `slog` logger instead of plain `fmt` statements, and introduces a centralized logging package with file and console output. Additionally, it updates all relevant command-line and Notion integration code to use the new logging approach.

**Logging Improvements:**

* Introduced a new `pkg/log/log.go` package that initializes a structured logger (`slog`) which logs to both a timestamped file and stdout, and provides a `Close()` method for cleanup.
* Updated `cmd/nankion/main.go` to initialize and close the logger at application start and shutdown, replacing all `fmt` output with structured `slog.Info` and `slog.Error` calls for command-line operations, including database fetching and property listing. [[1]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L4-R20) [[2]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L37-R47) [[3]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L54-R64) [[4]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L72-R79)

**Notion Integration Logging:**

* Replaced `fmt.Println` statements with `slog.Info` in `pkg/notion/notion.go` to log successful Notion page creation with relevant metadata. [[1]](diffhunk://#diff-0b58a60a77a42e21f8447a6b9c7c2ba142764e1066264cf1f62805441c28fa00R6) [[2]](diffhunk://#diff-0b58a60a77a42e21f8447a6b9c7c2ba142764e1066264cf1f62805441c28fa00L62-R63)