### PR TITLE
Rename UploadReport method to UploadStatement 

### DIFF
--- a/cmd/nankion/main.go
+++ b/cmd/nankion/main.go
@@ -74,7 +74,7 @@ func main() {
 			filePath := args[1]
 			slog.Info("Uploading statement...")
 			nl := nankionNotion.NewNotionLoader()
-			err := nl.UploadReport(databaseID, filePath)
+			err := nl.UploadStatement(databaseID, filePath)
 			if err != nil {
 				slog.Info("Error trying to update database: ", err)
 			}

--- a/pkg/notion/notion.go
+++ b/pkg/notion/notion.go
@@ -27,8 +27,8 @@ func NewNotionLoader() *Notion {
 	}
 }
 
-// UploadReport uploads a report to the Notion database
-func (n *Notion) UploadReport(databaseID, filePath string) error {
+// UploadStatement uploads a report to the Notion database
+func (n *Notion) UploadStatement(databaseID, filePath string) error {
 	if err := n.validateDatabase(databaseID); err != nil {
 		return fmt.Errorf("error trying to validate database: %s", err)
 	}

--- a/pkg/notion/notion_test.go
+++ b/pkg/notion/notion_test.go
@@ -225,7 +225,7 @@ func TestUploadReport(t *testing.T) {
 
 			os.Setenv("DATABASE_ID", test.envDatabaseId)
 
-			err := loader.UploadReport(test.envDatabaseId, test.filePath)
+			err := loader.UploadStatement(test.envDatabaseId, test.filePath)
 
 			// Check error expectations
 			if err != nil {


### PR DESCRIPTION
This pull request focuses on renaming a method for clarity and consistency across the codebase. The main change is the replacement of the `UploadReport` method with `UploadStatement`, along with corresponding updates to all usages and documentation.

Method renaming for clarity:

* Renamed the `UploadReport` method to `UploadStatement` in the `Notion` struct, updating the function name and its documentation to better reflect its purpose. (`pkg/notion/notion.go`)
* Updated all references to the renamed method in the main application logic (`cmd/nankion/main.go`) and in the test suite (`pkg/notion/notion_test.go`). [[1]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L77-R77) [[2]](diffhunk://#diff-9235542781305622c733ab1610e3bbce79581bf642b62016cfcbf6c51cd4362dL228-R228)