### PR TITLE
Update environment variable name for Notion client secret

### DIFF
--- a/pkg/notion/client/client.go
+++ b/pkg/notion/client/client.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NewClient() *notion.Client{
-	secret := os.Getenv("NOTION_CARMO_SECRET")
+	secret := os.Getenv("NOTION_SECRET")
 	if secret == ""{
 		panic("notion secret not found!")
 	}


### PR DESCRIPTION
This pull request updates the way the Notion API secret is loaded in the `pkg/notion/client/client.go` file to use a more generic environment variable name. This improves consistency and makes configuration easier.

* Environment variable name changed from `NOTION_CARMO_SECRET` to `NOTION_SECRET` for loading the Notion API secret in the `NewClient` function.