### PR TITLE
Refactor Notion integration to use a unified NotionLoader 

### DIFF
--- a/cmd/nankion/main.go
+++ b/cmd/nankion/main.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/rodrigoTcarmo/nankion/pkg/log"
 	nankionNotion "github.com/rodrigoTcarmo/nankion/pkg/notion"
-	notiondatabase "github.com/rodrigoTcarmo/nankion/pkg/notion/database"
 	"github.com/spf13/cobra"
 )
 
@@ -38,8 +37,8 @@ func main() {
 		Run: func(cmd *cobra.Command, args []string) {
 			databaseID := args[0]
 			slog.Info("Fetching database", "databaseID", databaseID)
-			databaseCLI := notiondatabase.NewDatabase()
-			database, err := databaseCLI.GetDatabase(databaseID)
+			nl := nankionNotion.NewNotionLoader()
+			database, err := nl.Database.GetDatabase(databaseID)
 			if err != nil {
 				slog.Error("Error fetching database", "error", err.Error())
 				return
@@ -55,8 +54,8 @@ func main() {
 		Run: func(cmd *cobra.Command, args []string) {
 			databaseID := args[0]
 			slog.Info("Fetching database properties", "databaseID", databaseID)
-			databaseCLI := notiondatabase.NewDatabase()
-			database, err := databaseCLI.ListDatabaseProperties(databaseID)
+			nl := nankionNotion.NewNotionLoader()
+			database, err := nl.Database.ListDatabaseProperties(databaseID)
 			if err != nil {
 				slog.Error("error fetching database properties", "error", err.Error())
 				return

--- a/pkg/notion/client/client.go
+++ b/pkg/notion/client/client.go
@@ -1,14 +1,21 @@
 package notion
 
 import (
+	"context"
 	"os"
 
 	"github.com/dstotijn/go-notion"
 )
 
-func NewClient() *notion.Client{
+type NotionClient interface {
+	FindDatabaseByID(context.Context, string) (notion.Database, error)
+	UpdateDatabase(context.Context, string, notion.UpdateDatabaseParams) (notion.Database, error)
+	CreatePage(context.Context, notion.CreatePageParams) (notion.Page, error)
+}
+
+func NewClient() NotionClient {
 	secret := os.Getenv("NOTION_SECRET")
-	if secret == ""{
+	if secret == "" {
 		panic("notion secret not found!")
 	}
 	return notion.NewClient(secret)

--- a/pkg/notion/database/database.go
+++ b/pkg/notion/database/database.go
@@ -15,7 +15,7 @@ type Database interface {
 }
 
 type database struct {
-	client *notion.Client
+	client notionclient.NotionClient
 }
 
 func (d *database) GetDatabase(databaseId string) (*notion.Database, error) {
@@ -50,8 +50,8 @@ func (d *database) UpsertDatabaseProperties(databaseId string, properties map[st
 	return nil
 }
 
-func NewDatabase() *database {
+func NewDatabase(client notionclient.NotionClient) *database {
 	return &database{
-		client: notionclient.NewClient(),
+		client: client,
 	}
 }

--- a/pkg/notion/notion.go
+++ b/pkg/notion/notion.go
@@ -14,16 +14,15 @@ import (
 )
 
 type Notion struct {
-	client   *notion.Client
-	database database.Database
-	page     page.Page
+	Database database.Database
+	Page     page.Page
 }
 
 func NewNotionLoader() *Notion {
+	notionClient := notionclient.NewClient()
 	return &Notion{
-		client:   notionclient.NewClient(),
-		database: database.NewDatabase(),
-		page:     page.NewPage(),
+		Database: database.NewDatabase(notionClient),
+		Page:     page.NewPage(notionClient),
 	}
 }
 
@@ -70,12 +69,12 @@ func (n *Notion) UploadStatements(databaseID, folderPath string) error {
 func (n *Notion) uploadPages(databaseID string, report *statement.Report) error {
 	var errs []error
 	for _, statement := range report.Statements {
-		newPage, err := n.page.BuildPage(databaseID, statement)
+		newPage, err := n.Page.BuildPage(databaseID, statement)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error trying to build page for %s: %w", statement.Destination, err))
 			continue
 		}
-		if err := n.page.CreatePage(*newPage); err != nil {
+		if err := n.Page.CreatePage(*newPage); err != nil {
 			errs = append(errs, fmt.Errorf("error trying to create page for %s: %w", statement.Destination, err))
 		} else {
 			slog.Info("Page successfully created", "memo", statement.Memo, "destination", statement.Destination)
@@ -86,7 +85,7 @@ func (n *Notion) uploadPages(databaseID string, report *statement.Report) error 
 }
 
 func (n *Notion) validateDatabase(databaseID string) error {
-	_, err := n.database.GetDatabase(databaseID)
+	_, err := n.Database.GetDatabase(databaseID)
 	if err != nil {
 		return err
 	}
@@ -109,7 +108,7 @@ func (n *Notion) validateDatabaseProperties(databaseID string) error {
 }
 
 func (n *Notion) getExistentProperties(databaseID string) (map[string]notion.DatabasePropertyType, error) {
-	databaseProperties, err := n.database.ListDatabaseProperties(databaseID)
+	databaseProperties, err := n.Database.ListDatabaseProperties(databaseID)
 	if err != nil {
 		return nil, fmt.Errorf("error trying to list database properties: %s", err)
 	}
@@ -133,7 +132,7 @@ func (n *Notion) mapMissingProperties(existentProperties map[string]notion.Datab
 }
 
 func (n *Notion) upsertDatabaseProperties(databaseID string, missingProperties map[string]*notion.DatabaseProperty) error {
-	if err := n.database.UpsertDatabaseProperties(databaseID, missingProperties); err != nil {
+	if err := n.Database.UpsertDatabaseProperties(databaseID, missingProperties); err != nil {
 		return fmt.Errorf("error trying to upsert new database properties: %s", err)
 	}
 

--- a/pkg/notion/notion_test.go
+++ b/pkg/notion/notion_test.go
@@ -211,7 +211,7 @@ func TestUploadReport(t *testing.T) {
 			}
 
 			loader := &Notion{
-				database: &databasemock.MockDatabaseClient{
+				Database: &databasemock.MockDatabaseClient{
 					GetDatabaseFunc: func(databaseId string) (*notion.Database, error) {
 						if test.mockDatabase != nil {
 							return test.mockDatabase(databaseId)
@@ -221,7 +221,7 @@ func TestUploadReport(t *testing.T) {
 					ListDatabasePropertiesFunc:   test.mockDatabaseProperties,
 					UpsertDatabasePropertiesFunc: mockUpsert,
 				},
-				page: mockPage,
+				Page: mockPage,
 			}
 
 			os.Setenv("DATABASE_ID", test.envDatabaseId)
@@ -426,7 +426,7 @@ func TestUploadPages(t *testing.T) {
 			}
 
 			n := &Notion{
-				page: mockPage,
+				Page: mockPage,
 			}
 
 			err := n.uploadPages(databaseID, test.report)
@@ -596,7 +596,7 @@ func TestUploadStatements(t *testing.T) {
 			}
 
 			loader := &Notion{
-				database: &databasemock.MockDatabaseClient{
+				Database: &databasemock.MockDatabaseClient{
 					GetDatabaseFunc: func(databaseId string) (*notion.Database, error) {
 						if test.mockDatabase != nil {
 							return test.mockDatabase(databaseId)
@@ -608,7 +608,7 @@ func TestUploadStatements(t *testing.T) {
 					},
 					UpsertDatabasePropertiesFunc: mockUpsert,
 				},
-				page: mockPage,
+				Page: mockPage,
 			}
 
 			folderPath := test.setupFolder(t)

--- a/pkg/notion/page/page.go
+++ b/pkg/notion/page/page.go
@@ -21,7 +21,7 @@ type PageData struct {
 }
 
 type page struct {
-	client *notion.Client
+	client notionclient.NotionClient
 }
 
 func (p *page) BuildPage(databaseID string, statement statement.Statement) (*PageData, error) {
@@ -69,8 +69,8 @@ func (p *page) BuildPageProperties(statement statement.Statement) (*notion.Datab
 	}, nil
 }
 
-func NewPage() Page {
+func NewPage(client notionclient.NotionClient) Page {
 	return &page{
-		client: notionclient.NewClient(),
+		client: client,
 	}
 }


### PR DESCRIPTION
This pull request refactors the Notion client integration to improve dependency injection and testability. The main change is to introduce a `NotionClient` interface and update the construction and usage of Notion-related objects to accept this interface, rather than hardcoding the client instantiation. This allows for easier mocking in tests and cleaner code separation.

**Dependency Injection and Interface Abstraction:**

* Introduced a `NotionClient` interface in `pkg/notion/client/client.go` and updated `NewClient()` to return this interface, enabling abstraction over the underlying Notion client implementation.
* Updated the `database` and `page` structs to accept a `NotionClient` via their constructors (`NewDatabase` and `NewPage`), instead of creating their own client instances. [[1]](diffhunk://#diff-8074ed1526d4bdc3fc935668ff10e678fe854e46c2a87fca974dc56fe2ca224cL18-R18) [[2]](diffhunk://#diff-8074ed1526d4bdc3fc935668ff10e678fe854e46c2a87fca974dc56fe2ca224cL53-R55) [[3]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L24-R24) [[4]](diffhunk://#diff-8586b3d71ba4b8ebd49ec03209d2be90e67bf1ed89ef01fa4e261340f70ffc52L72-R74)

**Refactoring of Notion Loader and Usage:**

* Refactored the `Notion` struct in `pkg/notion/notion.go` to export `Database` and `Page` fields (instead of unexported `database` and `page`), and updated the loader to inject the shared `NotionClient` into both. All references in methods and tests were updated to use the new field names. [[1]](diffhunk://#diff-0b58a60a77a42e21f8447a6b9c7c2ba142764e1066264cf1f62805441c28fa00L17-R25) [[2]](diffhunk://#diff-0b58a60a77a42e21f8447a6b9c7c2ba142764e1066264cf1f62805441c28fa00L73-R77) [[3]](diffhunk://#diff-0b58a60a77a42e21f8447a6b9c7c2ba142764e1066264cf1f62805441c28fa00L89-R88) [[4]](diffhunk://#diff-0b58a60a77a42e21f8447a6b9c7c2ba142764e1066264cf1f62805441c28fa00L112-R111) [[5]](diffhunk://#diff-0b58a60a77a42e21f8447a6b9c7c2ba142764e1066264cf1f62805441c28fa00L136-R135) [[6]](diffhunk://#diff-9235542781305622c733ab1610e3bbce79581bf642b62016cfcbf6c51cd4362dL214-R214) [[7]](diffhunk://#diff-9235542781305622c733ab1610e3bbce79581bf642b62016cfcbf6c51cd4362dL224-R224) [[8]](diffhunk://#diff-9235542781305622c733ab1610e3bbce79581bf642b62016cfcbf6c51cd4362dL429-R429) [[9]](diffhunk://#diff-9235542781305622c733ab1610e3bbce79581bf642b62016cfcbf6c51cd4362dL599-R599) [[10]](diffhunk://#diff-9235542781305622c733ab1610e3bbce79581bf642b62016cfcbf6c51cd4362dL611-R611)

**Command-line Integration:**

* Updated the CLI commands in `cmd/nankion/main.go` to use the new `NotionLoader` and its `Database` field, removing direct references to the old `notiondatabase` package and its constructors. [[1]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L9) [[2]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L41-R41) [[3]](diffhunk://#diff-4a193588c54152d6b13dc9f82a4677bf1fa7e6412b5a87d4f576039ff1bfe3c4L58-R58)